### PR TITLE
docs: add activity badge strip to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Extracted from 70+ production projects: *tier laundering* in agent authority, *s
 [![Task Prompts](https://img.shields.io/badge/Task_Prompts-43-green)](tasks/)
 [![Templates](https://img.shields.io/badge/Templates-3-teal)](templates/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/Stackbilt-dev/ai-playbook)](../../commits)
+[![Open Issues](https://img.shields.io/github/issues/Stackbilt-dev/ai-playbook)](../../issues)
 
 **If this helps you think better with AI, [give it a star](../../stargazers) -- it helps others find it too.**
 


### PR DESCRIPTION
Closes #6

Adds two dynamic shields.io badges to the existing badge row near the top of the README:
- **Last Commit** — `github/last-commit/Stackbilt-dev/ai-playbook`, links to the commits page
- **Open Issues** — `github/issues/Stackbilt-dev/ai-playbook`, links to the issues page

Additive only — existing badges (Vibecoding Archetypes, Frameworks, Claude Code Skills, Task Prompts, Templates, License) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)