### PR TITLE
docs: cross-link Charter from Context Engineering framework

### DIFF
--- a/frameworks/context-engineering/README.md
+++ b/frameworks/context-engineering/README.md
@@ -225,6 +225,7 @@ Monitor for unexpected capabilities:
 - Karpathy's Context Window Philosophy
 - Neural Field Theory Applications
 - Token Economics Research
+- [Charter](https://github.com/Stackbilt-dev/charter) operationalizes these principles as a CLI: ADF modules with per-module token budgets, trigger-loaded on demand.
 
 ## 🔮 Future Directions
 


### PR DESCRIPTION
Closes #8

Adds one bullet to the References section of frameworks/context-engineering/README.md pointing to Charter as the CLI implementation of these context-engineering principles.

Additive only — no other section touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)