### PR TITLE
docs: add coding-agent copy-paste prompt callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Extracted from 70+ production projects: *tier laundering* in agent authority, *s
 
 </div>
 
+## Using a Coding Agent?
+
+Copy this prompt to add AI Playbook to your project:
+
+```
+Read https://github.com/Stackbilt-dev/ai-playbook and copy the parts
+relevant to this project: Claude Code skills from claude-code/skills/
+into .claude/skills/, and if this project runs autonomous agents, the
+patterns in frameworks/agent-governance/ and
+frameworks/production-ai-patterns/. Follow the repo's Quick Start
+section for exact copy commands.
+```
+
 ---
 
 ## Quick Start (60 seconds)


### PR DESCRIPTION
Closes #12

Adds a "Using a Coding Agent?" callout section right after the hero/badge block, giving users a copy-paste prompt to onboard AI Playbook via a coding agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)